### PR TITLE
meintain docker command readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ docker run --name some-goddd \
   --link some-pathfinder:pathfinder \
   -p 8080:8080 \
   -e ROUTINGSERVICE_URL=http://pathfinder:8080 \
-  marcusolsson/goddd /goddd -inmem
+  marcusolsson/goddd -inmem
 ```
 
 ... or if you're using Docker Compose:


### PR DESCRIPTION
by this line `marcusolsson/goddd /goddd -inmem`
we got 
```
panic: no reachable servers

goroutine 1 [running]:
main.main()
	/go/src/github.com/marcusolsson/goddd/cmd/shippingsvc/main.go:74 +0x1dc2
```
the command should be without `/goddd`